### PR TITLE
Clarify AI guidance for event relays and tests; consume forwarded events

### DIFF
--- a/tests/unit/layer/test_PointerDefault_Composition.cpp
+++ b/tests/unit/layer/test_PointerDefault_Composition.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Composition: mouse -> mixer -> alias (user-level wiring, providers ar
     std::thread forwarder([&] {
         while (forwarderRunning.load(std::memory_order_acquire)) {
             // Block briefly waiting for a mouse event; on success, translate to pointer mixer event.
-            auto r = mouseRaw->read<"/events", PathIOMouse::Event>(Block{50ms});
+            auto r = mouseRaw->take<"/events", PathIOMouse::Event>(Block{50ms});
             if (r.has_value()) {
                 auto const& mev = *r;
                 PathIOPointerMixer::Event pev;


### PR DESCRIPTION
Purpose
- Strengthen AI-facing docs to prevent event duplication and flaky tests when composing providers and alias layers.

AI Change Log
- docs/AI_OVERVIEW.md: Add guidance on read vs take, provider notify, cooperative shutdown, and testing merged streams.
- docs/AI_ARCHITECTURE.md: Expand Views section with alias notify forwarding, iterator tail note, and provider/forwarder patterns.
- tests/unit/layer/test_PointerDefault_Composition.cpp: Use take() in forwarder to avoid duplicating events into the mixer.