### PR TITLE
Consolidate unmerged AI doc guidance and test forwarder fix

### DIFF
--- a/tests/unit/layer/test_PointerDefault_Composition.cpp
+++ b/tests/unit/layer/test_PointerDefault_Composition.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Composition: mouse -> mixer -> alias (user-level wiring, providers ar
     std::thread forwarder([&] {
         while (forwarderRunning.load(std::memory_order_acquire)) {
             // Block briefly waiting for a mouse event; on success, translate to pointer mixer event.
-            auto r = mouseRaw->read<"/events", PathIOMouse::Event>(Block{50ms});
+            auto r = mouseRaw->take<"/events", PathIOMouse::Event>(Block{50ms});
             if (r.has_value()) {
                 auto const& mev = *r;
                 PathIOPointerMixer::Event pev;


### PR DESCRIPTION
Purpose
- Consolidate remaining unmerged changes into a single PR against master.

AI Change Log
- docs/AI_OVERVIEW.md: Add read vs take guidance; provider notify; alias notify forwarding; bounded waits and cooperative shutdown.
- docs/AI_ARCHITECTURE.md: Expand Views section with alias notify forwarding and provider/forwarder patterns.
- tests/unit/layer/test_PointerDefault_Composition.cpp: Use take() in forwarder to consume events and avoid duplication.

Notes
- These changes were previously proposed on topic branches but not yet present on master after recent merges.