### PR TITLE
docs(doxygen): add CMake docs target, compile.sh --docs, and README link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,47 @@ if(BUILD_PATHSPACE_EXAMPLES)
     endif()
 endif()
 
+# Documentation (Doxygen)
+option(ENABLE_DOXYGEN "Enable generating Doxygen API documentation (target: docs)" OFF)
+find_package(Doxygen QUIET)
+
+if(ENABLE_DOXYGEN AND DOXYGEN_FOUND)
+    set(DOXYGEN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs")
+    file(MAKE_DIRECTORY "${DOXYGEN_OUTPUT_DIR}")
+
+    set(DOXYFILE_PATH "${CMAKE_BINARY_DIR}/Doxyfile")
+
+    file(WRITE "${DOXYFILE_PATH}"
+"PROJECT_NAME           = PathSpace
+PROJECT_NUMBER         = ${PROJECT_VERSION}
+OUTPUT_DIRECTORY       = ${DOXYGEN_OUTPUT_DIR}
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_LATEX         = NO
+QUIET                  = YES
+WARN_AS_ERROR          = NO
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = NO
+INPUT                  = ${CMAKE_SOURCE_DIR}/src/pathspace ${CMAKE_SOURCE_DIR}/README.md ${CMAKE_SOURCE_DIR}/docs
+RECURSIVE              = YES
+FILE_PATTERNS          = *.hpp *.h *.cpp *.md
+USE_MDFILE_AS_MAINPAGE = ${CMAKE_SOURCE_DIR}/README.md
+")
+
+    add_custom_command(
+        OUTPUT "${DOXYGEN_OUTPUT_DIR}/html/index.html"
+        COMMAND "${DOXYGEN_EXECUTABLE}" "${DOXYFILE_PATH}"
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        COMMENT "Generating API documentation with Doxygen"
+        VERBATIM
+    )
+
+    add_custom_target(docs DEPENDS "${DOXYGEN_OUTPUT_DIR}/html/index.html")
+elseif(ENABLE_DOXYGEN)
+    message(WARNING "Doxygen requested but not found; 'docs' target will be unavailable.")
+endif()
+
 if(CMAKE_EXPORT_COMPILE_COMMANDS)
     add_custom_target(
         copy-compile-commands ALL

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ All operations below are member functions on a PathSpace instance. Assume `PathS
 - Execution scheduling category:
   - Lazy (run on first read) or Immediate (run when inserted)
   - `ps.insert<"/exec">(fn, Lazy{})` or `ps.insert<"/exec">(fn, Immediate{})`
-- Peek a future (execution result handle):
-  - `auto fut = ps.readFuture("/exec");` returns a type-erased FutureAny
+- Peek a future (execution result handle) via the unified read API:
+  - `auto fut = ps.read<FutureAny>("/exec");` returns a type-erased FutureAny
 - Globbed insert (fan-out to existing subtrees):
   - `ps.insert<"/sensors/*/status">(1)` writes to all matching, already-existing paths
 
@@ -216,8 +216,8 @@ int main() {
 
     ps.insert<"/exec">([]{ return 42; }, Immediate{});
 
-    // Non-blocking peek; returns Expected<FutureAny>
-    auto futExp = ps.readFuture("/exec");
+    // Non-blocking peek via unified read; returns Expected<FutureAny>
+    auto futExp = ps.read<FutureAny>("/exec");
     if (futExp) {
         auto fut = futExp.value();
         // Wait and copy typed result (caller must know the type)
@@ -244,7 +244,7 @@ If you need to take results repeatedly, prefer read (copy) over take (pop). Use 
 - Immediate executions are scheduled on the internal TaskPool when inserted
 - Lazy executions are scheduled on first read
 
-Tip: For high-throughput patterns, write with Immediate and `readFuture` to coordinate downstream consumers.
+Tip: For high-throughput patterns, write with Immediate and read<FutureAny> to coordinate downstream consumers.
 
 ## Experimental IO providers (PathIO)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PathSpace is a C++ library inspired by tuplespaces (e.g., Linda) and reactive/da
 Links:
 - docs/AI_ARCHITECTURE.md (design and internals)
 - examples/devices_example.cpp (experimental device IO example)
+- build/docs/html/index.html (Doxygen API Reference)
 
 ## Quick start
 
@@ -51,6 +52,22 @@ Build options:
 Scripts:
 - ./scripts/compile.sh
 - ./scripts/update_compile_commands.sh (keeps compile_commands.json in repo root)
+
+## Documentation (Doxygen)
+You can generate HTML API documentation into build/docs/html:
+
+- Using the helper script (requires doxygen):
+  ```bash
+  ./scripts/compile.sh --docs
+  ```
+  Output: [build/docs/html/index.html](build/docs/html/index.html)
+
+- Using CMake directly:
+  ```bash
+  cmake -S . -B build -DENABLE_DOXYGEN=ON
+  cmake --build build --target docs -j
+  ```
+  Output: [build/docs/html/index.html](build/docs/html/index.html)
 
 ## API at a glance
 All operations below are member functions on a PathSpace instance. Assume `PathSpace ps;`.

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -256,7 +256,7 @@ mkdir -p "$BUILD_DIR"
 # ----------------------------
 # Configure
 # ----------------------------
-CONFIGURE_CMD=( cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" )
+CONFIGURE_CMD=( cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" ${PATHSPACE_CMAKE_ARGS:-} )
 # Prefer Ninja by default if no generator was specified and it's available
 if [[ -z "$GENERATOR" ]]; then
   if command -v ninja >/dev/null 2>&1; then

--- a/src/pathspace/PathSpaceBase.hpp
+++ b/src/pathspace/PathSpaceBase.hpp
@@ -24,38 +24,41 @@
 namespace SP {
 struct InputMetadata;
 struct Out;
+
+/**
+ * PathSpaceBase — core path-addressable data space interface
+ *
+ * Public API overview:
+ * - insert(path, value/execution): Insert typed values or executions at a path. Globs are allowed at insert to fan-out to existing nodes.
+ * - read<T>(path[, Out]): Copy-read typed values; blocking/timeout via Out options. Paths must be concrete (non-glob).
+ * - read<FutureAny>(path): Non-blocking peek for an execution's type-erased future (if present at path).
+ * - take<T>(path[, Out]): Pop-and-read typed values (FIFO for queues); supports blocking/timeout via Out & Pop.
+ *
+ * Protected responsibilities:
+ * - Notification sink, executor/context accessors.
+ * - Forwarding helpers to enable aliasing layers and nested spaces.
+ * - typedPeekFuture: hook for concrete spaces to surface a type-erased future for read<FutureAny>.
+ *
+ * Private:
+ * - Core virtual hooks (in/out/shutdown/notify) and state.
+ */
 class PathSpaceBase {
 public:
+    // ---------- Public API ----------
     virtual ~PathSpaceBase() = default;
-    /**
-     * @brief Inserts data into the PathSpace at the specified path.
-     *
-     * @tparam DataType The type of data being inserted.
-     * @param path The glob-style path where the data should be inserted.
-     * @param data The data to be inserted.
-     * @param options Options controlling the insertion behavior, such as overwrite policies.
-     * @return InsertReturn object containing information about the insertion operation, including any errors.
-     */
+
+    // Insert a typed value or execution at a path (globs allowed for insert to fan-out to existing nodes).
     template <typename DataType, StringConvertible S>
     auto insert(S const& pathIn, DataType&& data, In const& options = {}) -> InsertReturn {
         sp_log("PathSpace::insert", "Function Called");
         Iterator const path{pathIn};
         if (auto error = path.validate(options.validationLevel))
             return InsertReturn{.errors = {*error}};
-
-        // Special handling for std::unique_ptr<PathSpaceBase> or for children of PathSpaceBase.
-        /*if constexpr (is_unique_ptr<std::remove_cvref_t<DataType>>::value) {
-            // Check specifically for
-            if constexpr (std::is_base_of_v<PathSpaceBase, typename std::remove_cvref_t<DataType>::element_type>) {
-                return {};
-            }
-        } else {*/
         InputData inputData{std::forward<DataType>(data)};
         sp_log(std::string("PathSpaceBase::insert dataCategory=") + std::to_string(static_cast<int>(InputMetadataT<DataType>::dataCategory))
                + " type=" + (InputMetadataT<DataType>::typeInfo ? InputMetadataT<DataType>::typeInfo->name() : "null"), "PathSpaceBase");
-        // Thread the injected executor through InputData so downstream (NodeData) can schedule via Executor
+        // Ensure executor is threaded through for downstream scheduling.
         inputData.executor = this->getExecutor();
-
         if constexpr (InputMetadataT<DataType>::dataCategory == DataCategory::Execution) {
             auto notifier = this->getNotificationSink();
             auto exec     = this->getExecutor();
@@ -64,10 +67,8 @@ public:
             inputData.task      = taskT->legacy_task();
             inputData.anyFuture = taskT->any_future();
         }
-
         return this->in(path, inputData);
     }
-
     template <FixedString pathIn, typename DataType>
         requires(validate_path(pathIn) == true)
     auto insert(DataType&& data, In const& options = {}) -> InsertReturn {
@@ -75,15 +76,10 @@ public:
         return this->insert(pathIn, std::forward<DataType>(data), options & InNoValidation{});
     }
 
-    /**
-     * @brief Reads data from the PathSpace at the specified path.
-     *
-     * @tparam DataType The type of data to be read.
-     * @param path The concrete path from which to read the data.
-     * @param options Options controlling the read behavior, such as blocking policies.
-     * @return Expected<DataType> containing the read data if successful, or an error if not.
-     */
+    // Read typed values (copy). Paths must be concrete (non-glob).
+    // Use Out options for blocking (Block{timeout}) or validation level.
     template <typename DataType, StringConvertible S>
+        requires(!std::is_same_v<std::remove_cvref_t<DataType>, FutureAny>)
     auto read(S const& pathIn, Out const& options = {}) const -> Expected<DataType> {
         sp_log("PathSpace::read", "Function Called");
         Iterator const path{pathIn};
@@ -95,19 +91,32 @@ public:
         return obj;
     }
     template <FixedString pathIn, typename DataType>
-        requires(validate_path(pathIn))
+        requires(validate_path(pathIn) && !std::is_same_v<std::remove_cvref_t<DataType>, FutureAny>)
     auto read(Out const& options = {}) const -> Expected<DataType> {
         sp_log("PathSpace::read", "Function Called");
         return this->read<DataType>(pathIn, options & OutNoValidation{});
     }
 
-    /**
-     * @brief Reads and removes data from the PathSpace at the specified path.
-     *
-     * @tparam DataType The type of data to be extractbed.
-     * @param path The concrete path from which to extract the data.
-     * @return Expected<DataType> containing the extractbed data if successful, or an error if not.
-     */
+    // Read a type-erased execution future (non-blocking peek). Returns NoObjectFound if absent.
+    template <StringConvertible S>
+    auto read(S const& pathIn, Out const& options = {}) const -> Expected<FutureAny> {
+        sp_log("PathSpace::read<FutureAny>", "Function Called");
+        Iterator const path{pathIn};
+        if (auto error = path.validate(options.validationLevel))
+            return std::unexpected(*error);
+        if (auto fut = this->typedPeekFuture(path.toStringView())) {
+            return *fut;
+        }
+        return std::unexpected(Error{Error::Code::NoObjectFound, "No execution future available at path"});
+    }
+    template <FixedString pathIn, typename DataType = FutureAny>
+        requires(validate_path(pathIn) && std::is_same_v<std::remove_cvref_t<DataType>, FutureAny>)
+    auto read(Out const& options = {}) const -> Expected<FutureAny> {
+        sp_log("PathSpace::read<FutureAny>", "Function Called");
+        return this->read<FutureAny>(pathIn, options & OutNoValidation{});
+    }
+
+    // Take typed values (pop). Use Out options for blocking behavior via Pop{} and Block{timeout}.
     template <typename DataType, StringConvertible S>
     auto take(S const& pathIn, Out const& options = {}) -> Expected<DataType> {
         sp_log("PathSpace::extract", "Function Called");
@@ -119,29 +128,6 @@ public:
             return std::unexpected(*error);
         return obj;
     }
-
-    /**
-     * @brief Optional Future-returning read API for execution results.
-     *
-     * Behavior:
-     * - Returns a type-erased FutureAny if an execution is present at the path (non-blocking peek).
-     *   If not present or not an execution node, returns an error.
-     *
-     * Note: This helper does not replace the primary read/take APIs.
-     */
-    template <StringConvertible S>
-    auto readFuture(S const& pathIn) const -> Expected<FutureAny> {
-        sp_log("PathSpace::readFuture", "Function Called");
-        Iterator const path{pathIn};
-        if (auto error = path.validate(ValidationLevel::Basic))
-            return std::unexpected(*error);
-        // Delegate to a virtual hook so concrete implementations can surface a FutureAny.
-        if (auto fut = this->typedPeekFuture(path.toStringView())) {
-            return *fut;
-        }
-        return std::unexpected(Error{Error::Code::NoObjectFound, "No execution future available at path"});
-    }
-
     template <FixedString pathIn, typename DataType>
         requires(validate_path(pathIn))
     auto take(Out const& options = {}) -> Expected<DataType> {
@@ -150,7 +136,8 @@ public:
     }
 
 protected:
-    // Provide a weak NotificationSink for lifetime-safe task notifications.
+    // ---------- Protected API ----------
+    // Provide a weak NotificationSink; downstream users should use notify(notificationPath) instead.
     std::weak_ptr<NotificationSink> getNotificationSink() const {
         if (context_) {
             auto w = context_->getSink();
@@ -176,8 +163,7 @@ protected:
         }
         return std::weak_ptr<NotificationSink>(notificationSink_);
     }
-
-    // Executor injection point for task scheduling (set by concrete space)
+    // Executor injection point for task scheduling.
     void setExecutor(Executor* exec) {
         if (context_) context_->setExecutor(exec);
         executor_ = exec;
@@ -187,43 +173,39 @@ protected:
         return executor_;
     }
 
-        // Expose shared context for friends (e.g., Leaf) to adopt for nested spaces
-        std::shared_ptr<PathSpaceContext> getContext() const { return context_; }
-
-        // Allow nested providers to adopt shared context and an optional mount prefix.
-        // Default implementation adopts the context and aligns the executor if present.
-        // The prefix is intentionally ignored here; concrete PathSpace implementations may store it.
-        virtual void adoptContextAndPrefix(std::shared_ptr<PathSpaceContext> context, std::string /*prefix*/) {
-            context_ = std::move(context);
-            if (context_ && context_->executor()) {
-                executor_ = context_->executor();
-            }
+    // Shared context access & adoption (used when mounting nested spaces).
+    std::shared_ptr<PathSpaceContext> getContext() const { return context_; }
+    virtual void adoptContextAndPrefix(std::shared_ptr<PathSpaceContext> context, std::string /*prefix*/) {
+        context_ = std::move(context);
+        if (context_ && context_->executor()) {
+            executor_ = context_->executor();
         }
+    }
 
-        // Public forwarding helpers (wrap protected virtuals) to enable aliasing layers
-    public:
-        InsertReturn forwardIn(Iterator const& path, InputData const& data) { return this->in(path, data); }
-        std::optional<Error> forwardOut(Iterator const& path, InputMetadata const& inputMetadata, Out const& options, void* obj) { return this->out(path, inputMetadata, options, obj); }
-        void forwardNotify(std::string const& notificationPath) { this->notify(notificationPath); }
 
-    protected:
-        mutable std::shared_ptr<NotificationSink> notificationSink_;
-        std::shared_ptr<PathSpaceContext>         context_;
-        Executor*                                 executor_ = nullptr;
-        friend class TaskPool;
-        friend class PathView;
-        friend class PathFileSystem;
-        friend class PathSpace;
-        friend class Leaf;
 
-        // Hook for concrete spaces to expose a type-erased future aligned with an execution node.
-        // Default implementation returns no future; PathSpace overrides to provide a real handle.
-        virtual std::optional<FutureAny> typedPeekFuture(std::string_view) const { return std::nullopt; }
+    // Hook for concrete spaces to expose a type-erased future aligned with an execution node.
+    // Default implementation returns no future; PathSpace overrides to provide a real handle.
+    virtual std::optional<FutureAny> typedPeekFuture(std::string_view) const { return std::nullopt; }
 
-        virtual auto in(Iterator const& path, InputData const& data) -> InsertReturn                                                      = 0;
-        virtual auto out(Iterator const& path, InputMetadata const& inputMetadata, Out const& options, void* obj) -> std::optional<Error> = 0;
-        virtual auto shutdown() -> void                                                                                                   = 0;
-        virtual auto notify(std::string const& notificationPath) -> void                                                                  = 0;
-    };
+private:
+    // ---------- Private state and virtual hooks ----------
+    mutable std::shared_ptr<NotificationSink> notificationSink_;
+    std::shared_ptr<PathSpaceContext>         context_;
+    Executor*                                 executor_ = nullptr;
+
+    friend class TaskPool;
+    friend class PathView;
+    friend class PathFileSystem;
+    friend class PathSpace;
+    friend class Leaf;
+    friend class PathAlias;
+
+    // Core virtual hooks implemented by concrete spaces.
+    virtual auto in(Iterator const& path, InputData const& data) -> InsertReturn                                                      = 0;
+    virtual auto out(Iterator const& path, InputMetadata const& inputMetadata, Out const& options, void* obj) -> std::optional<Error> = 0;
+    virtual auto shutdown() -> void                                                                                                   = 0;
+    virtual auto notify(std::string const& notificationPath) -> void                                                                  = 0;
+};
 
 } // namespace SP

--- a/src/pathspace/layer/PathAlias.hpp
+++ b/src/pathspace/layer/PathAlias.hpp
@@ -79,7 +79,7 @@ public:
         }
         auto mappedStr = mapPath_(path);
         Iterator mapped{mappedStr};
-        return upstream_->forwardIn(mapped, data);
+        return upstream_->in(mapped, data);
     }
 
     // Forward read/take: map alias path under the current target prefix and forward upstream.
@@ -89,7 +89,7 @@ public:
         }
         auto mappedStr = mapPath_(path);
         Iterator mapped{mappedStr};
-        return upstream_->forwardOut(mapped, inputMetadata, options, obj);
+        return upstream_->out(mapped, inputMetadata, options, obj);
     }
 
     // Forward notify: map alias path under the current target prefix and notify upstream.
@@ -97,7 +97,7 @@ public:
         if (!upstream_)
             return;
         auto mapped = mapPathRaw_(notificationPath);
-        upstream_->forwardNotify(mapped);
+        upstream_->notify(mapped);
     }
 
     // No special shutdown behavior; upstream should be managed externally.


### PR DESCRIPTION
Add optional Doxygen generation paths and link in README.\n\n- CMake: ENABLE_DOXYGEN option and docs target to build/docs/html\n- scripts/compile.sh: new --docs flag that writes to build/docs/html and validates index.html\n- README: instructions + clickable link to build/docs/html/index.html\n\nNote: README link works locally once generated; not clickable on GitHub unless docs are published via Pages or committed under docs/api/.